### PR TITLE
Handle VM cleanup on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ provisioner:
 swift run sand --config sand.yml
 ```
 
-sand runs forever by default. Set `stopAfter` to stop after N iterations, or stop it early with Ctrl+C.
+sand runs forever by default. Set `stopAfter` to stop after N iterations, or stop it early with Ctrl+C. On Ctrl+C (SIGINT) or SIGTERM, sand attempts to stop and delete the current `ephemeral` VM before exiting.
 
 Logs are emitted to stdout by default.
 
@@ -105,7 +105,7 @@ provision
 5. Executes the provisioner inside the VM.
 6. Stops and deletes the `ephemeral` VM.
 
-If the process is interrupted, you can clean up manually:
+If cleanup does not complete (for example, if Tart is unavailable), you can clean up manually:
 
 ```
 tart stop ephemeral

--- a/Sources/sand/SignalHandler.swift
+++ b/Sources/sand/SignalHandler.swift
@@ -1,0 +1,37 @@
+import Darwin
+import Foundation
+import Logging
+
+final class SignalHandler {
+    private let lock = NSLock()
+    private var didHandle = false
+    private let logger: Logger
+    private var sources: [DispatchSourceSignal] = []
+
+    init(signals: [Int32], logger: Logger, handler: @escaping () -> Void) {
+        self.logger = logger
+        for signalValue in signals {
+            signal(signalValue, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: signalValue, queue: DispatchQueue.global())
+            source.setEventHandler { [weak self] in
+                guard let self else {
+                    return
+                }
+                self.lock.lock()
+                if self.didHandle {
+                    self.lock.unlock()
+                    return
+                }
+                self.didHandle = true
+                self.lock.unlock()
+
+                self.logger.info("received signal \(signalValue), cleaning up")
+                handler()
+                let exitCode = Int32(128) + signalValue
+                exit(exitCode)
+            }
+            source.resume()
+            sources.append(source)
+        }
+    }
+}

--- a/Sources/sand/VMShutdownCoordinator.swift
+++ b/Sources/sand/VMShutdownCoordinator.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Logging
+
+final class VMShutdownCoordinator {
+    private let lock = NSLock()
+    private var activeName: String?
+    private var cleanupStarted = false
+    private let logger: Logger
+
+    init(logger: Logger) {
+        self.logger = logger
+    }
+
+    func activate(name: String) {
+        lock.lock()
+        activeName = name
+        cleanupStarted = false
+        lock.unlock()
+    }
+
+    func cleanup(tart: Tart) {
+        lock.lock()
+        guard !cleanupStarted, let name = activeName else {
+            lock.unlock()
+            return
+        }
+        cleanupStarted = true
+        lock.unlock()
+
+        logger.info("stop VM \(name)")
+        try? tart.stop(name: name)
+        logger.info("delete VM \(name)")
+        try? tart.delete(name: name)
+
+        lock.lock()
+        activeName = nil
+        lock.unlock()
+    }
+}


### PR DESCRIPTION
## Summary
- add a shutdown coordinator so VM stop/delete runs once per iteration
- trap SIGINT/SIGTERM to stop and delete the active VM before exiting
- document automatic cleanup behavior on interrupt

## Testing
- not run (not requested)
