### PR TITLE
Add brew deps for tart and sshpass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - uses: swift-actions/setup-swift@v2
@@ -14,7 +14,7 @@ jobs:
           swift-version: "6.2"
       - run: swift test
   brew:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       HOMEBREW_NO_AUTO_UPDATE: "1"
     steps:

--- a/Formula/sand.rb
+++ b/Formula/sand.rb
@@ -29,7 +29,7 @@ class Sand < Formula
 
   def caveats
     <<~EOS
-      sand requires macOS 14+ and Tart available in your PATH.
+      sand requires macOS 15+ and Tart available in your PATH.
     EOS
   end
 end


### PR DESCRIPTION
Adds tap-qualified tart and sshpass dependencies to the sand formula so brew installs required CLIs automatically.